### PR TITLE
Added commandline support for alternate location of pcurses.conf file

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,10 @@ public:
     std::string getpcursesconffile() const {
         return pcursesconffile;
     }
+    std::string setpcursesconffile(const std::string s) {
+        pcursesconffile = s;
+        return pcursesconffile;
+    }
     std::string getrootdir() const {
         return rootdir;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,19 +22,24 @@
 #include "pcursesexception.h"
 #include "program.h"
 
+static char* opt_pcursesconffile = NULL;
+
 void parseargs(int argc, char *argv[])
 {
     int opt;
 
-    while ((opt = getopt(argc, argv, "hv")) != -1) {
+    while ((opt = getopt(argc, argv, "hvf:")) != -1) {
         switch (opt) {
+        case 'f':
+            opt_pcursesconffile = optarg;
+            break;
         case 'v':
             fprintf(stdout, "%s %d\n", APPLICATION_NAME, VERSION);
             exit(EXIT_SUCCESS);
             break;
         case 'h':
         default:
-            fprintf(stderr, "Usage: %s [-h] [-v]\n", APPLICATION_NAME);
+            fprintf(stderr, "Usage: %s [-h] [-v] [-f %s.conf]\n", APPLICATION_NAME, APPLICATION_NAME);
             exit(EXIT_FAILURE);
         }
     }
@@ -49,7 +54,7 @@ int main(int argc, char *argv[])
     Program *p = new Program();
 
     try {
-        p->init();
+        p->init(opt_pcursesconffile);
         p->mainloop();
     } catch (PcursesException e) {
         err = e.getmessage();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -109,8 +109,12 @@ void Program::init_misc()
     execmacro("startup");
 }
 
-void Program::init()
+void Program::init(char* opt_pcursesconffile)
 {
+    if (opt_pcursesconffile) {
+        conf.setpcursesconffile(opt_pcursesconffile);
+    }
+
     loadpkgs();
 
     CursesUi::ui().enable_curses(&filteredpackages, &opqueue);

--- a/src/program.h
+++ b/src/program.h
@@ -30,7 +30,7 @@ public:
     Program();
     ~Program();
 
-    void init();
+    void init(char* opt_pcursesconffile = NULL);
     void mainloop();
 
 private:


### PR DESCRIPTION
Working and testing new features like the new %filter_clear requires you to modify the pcurses.conf file with new experimantal options that will not work with the stable version of pcurses (the one I use to install pkgs and keep my system updates.

This patch will add commandline support for alternate location of pcurses.conf file

pcurses -f somelocation.conf

/Uffe
