### PR TITLE
Show "Required by" and "Optionally required by" fields for local packages

### DIFF
--- a/src/attributeinfo.cpp
+++ b/src/attributeinfo.cpp
@@ -54,6 +54,8 @@ AttributeEnum AttributeInfo::chartoattr(char c)
         return A_OPTDEPENDS;
     case 'p':
         return A_PROVIDES;
+    case 'q':
+        return A_REQUIREDBY;
     case 'r':
         return A_REPO;
     case 's':
@@ -64,6 +66,8 @@ AttributeEnum AttributeInfo::chartoattr(char c)
         return A_URL;
     case 'v':
         return A_VERSION;
+    case 'y':
+        return A_OPTIONALFOR;
     case 'z':
         return A_SIZE;
     default:
@@ -112,6 +116,10 @@ string AttributeInfo::attrname(AttributeEnum attr)
         return "Provides";
     case A_REPLACES:
         return "Replaces";
+    case A_REQUIREDBY:
+        return "Required by";
+    case A_OPTIONALFOR:
+        return "Optionally required by";
     case A_REPO:
         return "Repo";
     case A_SIGNATURE:

--- a/src/attributeinfo.h
+++ b/src/attributeinfo.h
@@ -40,6 +40,8 @@ enum AttributeEnum {
     A_CONFLICTS,
     A_PROVIDES,
     A_REPLACES,
+    A_REQUIREDBY,
+    A_OPTIONALFOR,
     A_SIZE,
     A_ISIZE,
     A_OPTDEPENDS,

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -68,6 +68,14 @@ Package::Package(alpm_pkg_t *pkg, alpm_db_t *localdb)
         _localversion = alpm_pkg_get_version(_localpkg);
         _updatestate = (alpm_pkg_vercmp(_version.c_str(), _localversion.c_str()) > 0) ?
                        USE_UPDATEAVAILABLE : USE_UPTODATE;
+
+        alpm_list_t *requiredbylist = alpm_pkg_compute_requiredby(_localpkg);
+        _requiredby = list2str(requiredbylist, " ");
+        alpm_list_free(requiredbylist);
+
+        alpm_list_t *optionalforlist = alpm_pkg_compute_optionalfor(_localpkg);
+        _optionalfor = list2str(optionalforlist, " ");
+        alpm_list_free(optionalforlist);
     }
 
     _reason = ((_localpkg == NULL) ? IRE_NOTINSTALLED :
@@ -180,6 +188,10 @@ string Package::getattr(AttributeEnum attr) const
         return getprovides();
     case A_REPLACES:
         return getreplaces();
+    case A_REQUIREDBY:
+        return getrequiredby();
+    case A_OPTIONALFOR:
+        return getoptionalfor();
     case A_SIGNATURE:
         return getsignature();
     case A_SIZE:
@@ -308,6 +320,16 @@ string Package::getprovides() const
 string Package::getreplaces() const
 {
     return _replaces;
+}
+
+string Package::getrequiredby() const
+{
+    return _requiredby;
+}
+
+string Package::getoptionalfor() const
+{
+    return _optionalfor;
 }
 
 string Package::getsignature() const

--- a/src/package.h
+++ b/src/package.h
@@ -66,6 +66,8 @@ public:
     std::string getreason() const;
     std::string getreplaces() const;
     std::string getrepo() const;
+    std::string getrequiredby() const;
+    std::string getoptionalfor() const;
     std::string getsignature() const;
     std::string getsize() const;
     std::string getupdatestate() const;
@@ -102,6 +104,8 @@ private:
         _conflicts,
         _provides,
         _replaces,
+        _requiredby,
+        _optionalfor,
         _sizestr,
         _signature,
         _installsizestr,


### PR DESCRIPTION
I needed this to clean up some packages that were installed as dependencies once upon a time, but are no longer required by anything.

None of the letters in "Optional for" were available, so it's "Optionally required by". :/